### PR TITLE
Companion commit to shingled disasm upgrade commit that was made today

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/main.native
+/_build/
+/setup.data
+/setup.log
+/setup.ml

--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,5 @@
 PKG bap
+PKG x86_lifter
+S .
 B _build
 FLG -short-paths

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+SETUP=ocaml setup.ml -quiet
+default: all
+
+all: 
+	oasis setup -setup-update dynamic
+	touch setup.data
+	$(SETUP) -build -cflag -annot -cflag -bin-annot
+
+install:
+	$(SETUP) -install 
+
+clean:
+	ocaml setup.ml -clean

--- a/_oasis
+++ b/_oasis
@@ -1,0 +1,37 @@
+OASISFormat: 0.4
+Name:        x86_lifter
+Version:     0.1
+Synopsis:    A lifter for the x86 and x64 architectures.
+Authors:     Ivan Gotovchits <ivg@ieee.org>, Kenneth Adam Miller <kennethadammiller@gmail.com>
+Maintainers: Ivan Gotovchits <ivg@ieee.org>, Kenneth Adam Miller <kennethadammiller@gmail.com>
+License:     MIT
+Plugins:     META (0.4)
+AlphaFeatures: ocamlbuild_more_args
+BuildTools: ocamlbuild, camlp4o
+XOCamlbuildExtraArgs: -j 5
+BuildDepends:
+              bin_prot.syntax,
+              camlp4,
+              comparelib.syntax,
+              core_kernel,
+              enumerate.syntax,
+              faillib.syntax,
+              fieldslib.syntax,
+              herelib.syntax,
+              pa_ounit.syntax,
+              sexplib.syntax,
+              variantslib.syntax
+
+Library x86_lifter
+  Path:           .
+  Install:        true
+  Modules:	  Lift, Btx, Opcode, Decode, Env, Types
+  CompiledObject: best
+  BuildDepends:   core_kernel, bap, bap.plugins, bap.serialization, threads
+
+Executable test_lifter
+  Path:           .
+  MainIs:         main.ml
+  Install:        false
+  BuildDepends:   core_kernel, bap, bap.plugins, bap.serialization, threads
+  CompiledObject: best

--- a/lift.ml
+++ b/lift.ml
@@ -4,15 +4,10 @@ open Or_error
 
 module Dis = Disasm_expert.Basic
 
-type lifter = (mem * Dis.full_insn) list -> bil Or_error.t list
-
-
 module Lifter (Target : Target) = struct
   open Target
 
   module Btx = Btx.Reg(Target)
-
-  type obil = bil Or_error.t
 
   let lift mem insn = match Decode.opcode insn with
     | Some (#Opcode.btx_reg as op) ->
@@ -20,20 +15,23 @@ module Lifter (Target : Target) = struct
     | Some op -> Ok [Bil.special "unsupported instruction"]
     | None -> lift mem insn
 
-  let lift_insns insns : obil list =
+  let lift_insns insns : bil t list =
     let rec process acc = function
       | [] -> (List.rev acc)
-      | (mem,x) :: xs -> match Decode.prefix x with
+      | (mem, Some x) :: xs -> (match Decode.prefix x with
         | None ->
           let bil = match lift mem x with
             | Error _ as err -> err
             | Ok bil -> Ok bil in
           process (bil::acc) xs
         | Some pre -> match xs with
-          | [] ->
+          | []  ->
             let bil = error "trail prefix" pre Opcode.sexp_of_prefix in
             process (bil::acc) []
-          | (mem,y) :: xs ->
+          | (mem, None) :: xs ->
+            let bil = error "prefix to a nonexistant insn" pre Opcode.sexp_of_prefix in
+            process (bil::acc) []
+          | (mem, Some y) :: xs ->
             let bil = match lift mem y with
               | Error _ as err -> err
               | Ok bil -> match pre with
@@ -44,13 +42,14 @@ module Lifter (Target : Target) = struct
                 | `LOCK_PREFIX -> Ok (Bil.special "lock" :: bil)
                 | `DATA16_PREFIX -> Ok (Bil.special "data16" :: bil)
                 | `REX64_PREFIX -> Ok (Bil.special "rex64" :: bil) in
-            process (bil::acc) xs in
+            process (bil::acc) xs)
+      | (mem, None) :: _ ->
+        let bil = error "No insn for mem; failed disasm " mem (fun m -> Sexp.Atom (Memory.hexdump m) ) in
+        process (bil::acc) []
+          in
     process [] insns
 end
 
 
 module X32 = Lifter(IA32)
 module X64 = Lifter(AMD64)
-
-let x32 = X32.lift_insns
-let x64 = X64.lift_insns

--- a/lift.mli
+++ b/lift.mli
@@ -1,8 +1,34 @@
-open Core_kernel.Std
 open Bap.Std
-
-type lifter = (mem * Disasm_expert.Basic.full_insn) list -> bil Or_error.t list
-
-
-val x32 : lifter
-val x64 : lifter
+open Core_kernel.Std
+open Or_error
+module Dis = Bap.Std.Disasm_expert.Basic
+module Lifter : functor (Target : Target) -> sig
+  module Btx : sig
+    val lift : Opcode.btx_reg -> op array -> bil
+  end
+  val lift :
+    mem -> Dis.full_insn -> bil t
+  val lift_insns :
+    (mem * Dis.full_insn option)
+      list -> bil t list
+end
+module X32 : sig
+  module Btx : sig
+    val lift : Opcode.btx_reg -> op array -> bil
+  end
+  val lift :
+    mem -> Dis.full_insn -> bil t
+  val lift_insns :
+    (mem * Dis.full_insn option)
+      list -> bil t list
+end
+module X64 : sig
+  module Btx : sig
+    val lift : Opcode.btx_reg -> op array -> bil
+  end
+  val lift :
+    mem -> Dis.full_insn -> bil t
+  val lift_insns :
+    (mem * Dis.full_insn option)
+      list -> bil t list
+  end

--- a/main.ml
+++ b/main.ml
@@ -17,10 +17,7 @@ let disasm data =
   Dis.store_asm >>| Dis.store_kinds >>| fun dis ->
   Dis.run dis mem ~return:ident ~init:()
     ~stopped:(fun s () ->
-        Dis.insns s |> List.filter_map ~f:(function
-            | (mem,None) ->
-              printf "Disasm failed: @.%a@." Memory.pp mem; None
-            | (mem,Some insn) -> Some (mem,insn)) |> Lift.x64 |>
+        Dis.insns s |> Lift.X64.lift_insns |>
         List.iter ~f:(function
             | Error err -> printf "Lifter failed: @.%a@." Error.pp err
             | Ok bil -> printf "%a@." Bil.pp bil))

--- a/opam
+++ b/opam
@@ -1,0 +1,47 @@
+opam-version: "1.2"
+name: "x86_lifter"
+version: "master"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team, Kenneth Adam Miller <kennethadammiller@gmail.com>"
+homepage: "https://github.com/ivg/x86-lifter/"
+bug-reports: "https://github.com/ivg/x86-lifter/issues"
+dev-repo: "git://github.com/ivg/x86-lifter/"
+license: "MIT"
+build: [
+  [make]
+]
+
+install: [
+  [make "install"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "x86_lifter"]
+  ["rm" "-rf" "%{prefix}%/share/x86_lifter"]
+]
+
+depends: [
+    "bap"
+]
+
+depexts: [
+    [["ubuntu"] [
+        "libgmp-dev"
+        "libzip-dev"
+        "libcurl4-gnutls-dev"
+        "llvm-3.4-dev"
+        "time"
+        "clang"
+        "llvm"
+        "m4"
+     ]]
+     [["osx" "macports"] [
+        "gmp"
+        "llvm-3.4"
+        "graphviz"
+        "curl"
+        "libzip"
+     ]
+    ]
+]
+available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
This commit changes the accepted type of
the lifter's lift_insns function to be exactly
identical to Disassembler's insns's return type.
The result is slightly smoother code with less
fanagling with the type system, which may seem
puny, but is good when you write a lot of
different applications that all use the lifter
interface.

In addition, some minor changes include adding
ocamlbuild/oasis and opam integration so that
testing could be done. Other noise includes
.merlin, gitignore and Makefile changes.
